### PR TITLE
Changed MongoDbEventStore.Find, MongoDbSingleCollectionEventStore.Find overload type from System.Func<T, bool> to System.Linq.Expressions.Expression<System.Func<T, bool>>

### DIFF
--- a/src/MementoFX.Persistence.MongoDB/MongoDbEventStore.cs
+++ b/src/MementoFX.Persistence.MongoDB/MongoDbEventStore.cs
@@ -6,6 +6,7 @@ using MongoDB.Driver;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 
 namespace MementoFX.Persistence.MongoDB
@@ -66,7 +67,7 @@ namespace MementoFX.Persistence.MongoDB
         /// <typeparam name="T">The type of the event</typeparam>
         /// <param name="filter">The requirement</param>
         /// <returns>The events which satisfy the given requirement</returns>
-        public override IEnumerable<T> Find<T>(Func<T, bool> filter)
+        public override IEnumerable<T> Find<T>(Expression<Func<T, bool>> filter)
         {
             var collectionName = typeof(T).Name;
             var events = MongoDatabase.GetCollection<T>(collectionName).AsQueryable().Where(filter);

--- a/src/MementoFX.Persistence.MongoDB/MongoDbSingleCollectionEventStore.cs
+++ b/src/MementoFX.Persistence.MongoDB/MongoDbSingleCollectionEventStore.cs
@@ -6,6 +6,7 @@ using MongoDB.Driver;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 
 namespace MementoFX.Persistence.MongoDB
 {
@@ -59,7 +60,7 @@ namespace MementoFX.Persistence.MongoDB
             MongoCollection = MongoDatabase.GetCollection<BsonDocument>(collectionName ?? "DomainEvents");
         }
 
-        public override IEnumerable<T> Find<T>(Func<T, bool> filter)
+        public override IEnumerable<T> Find<T>(Expression<Func<T, bool>> filter)
         {
             var clrType = typeof(T);
             var events = new List<T>();
@@ -83,7 +84,7 @@ namespace MementoFX.Persistence.MongoDB
                 }
             }
 
-            return events.Where(filter);
+            return events.Where(filter.Compile());
         }
 
         public override IEnumerable<DomainEvent> RetrieveEvents(Guid aggregateId, DateTime pointInTime, IEnumerable<EventMapping> eventDescriptors, Guid? timelineId)


### PR DESCRIPTION
As described on main project's [issue #6](https://github.com/MementoFX/MementoFX/issues/6) and related [pull request](https://github.com/MementoFX/MementoFX/pull/8), this PR changes the overload types to support `System.Linq.Expressions.Expression<System.Func<T, bool>>` as filter type on MongoDbEventStore and MongoDbSingleCollectionEventStore implementations.